### PR TITLE
[feat] 週次レポート削除機能を追加 (#6)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -88,6 +88,23 @@
   background: rgba(16, 185, 129, 0.1);
 }
 
+.btn-danger {
+  background: #ef4444;
+  color: white;
+  font-weight: 700;
+  transition: all 0.2s ease;
+}
+
+.btn-danger:hover {
+  background: #dc2626;
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(239, 68, 68, 0.4);
+}
+
+.btn-danger:active {
+  transform: translateY(0);
+}
+
 /* ========================================
    Logo with Gradient
    ======================================== */

--- a/app/controllers/weekly_reports_controller.rb
+++ b/app/controllers/weekly_reports_controller.rb
@@ -1,6 +1,6 @@
 class WeeklyReportsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_weekly_report, only: [:show]
+  before_action :set_weekly_report, only: [:show, :destroy]
 
   # GET /weekly_reports/:id
   def show
@@ -33,6 +33,14 @@ class WeeklyReportsController < ApplicationController
       Date.current.beginning_of_week(:monday)
     )
     redirect_to existing_report, notice: "今週のレポートは既に生成済みです"
+  end
+
+  # DELETE /weekly_reports/:id
+  def destroy
+    @weekly_report.destroy!
+    redirect_to weekly_reports_path, notice: "レポートを削除しました"
+  rescue ActiveRecord::RecordNotDestroyed
+    redirect_to @weekly_report, alert: "レポートの削除に失敗しました"
   end
 
   # GET /weekly_reports

--- a/app/views/weekly_reports/index.html.erb
+++ b/app/views/weekly_reports/index.html.erb
@@ -21,7 +21,7 @@
   <% if @weekly_reports.any? %>
     <div class="space-y-4">
       <% @weekly_reports.each do |report| %>
-        <%= link_to weekly_report_path(report), class: "card rounded-xl p-4 sm:p-6 block hover:shadow-lg transition-shadow" do %>
+        <div class="card rounded-xl p-4 sm:p-6 hover:shadow-lg transition-shadow">
           <div class="flex justify-between items-start mb-3">
             <div>
               <h3 class="font-bold text-slate-900">
@@ -31,38 +31,49 @@
                 生成: <%= report.created_at.strftime('%Y/%m/%d %H:%M') %>
               </p>
             </div>
-            <% if report.summary_data.present? && report.summary_data['avg_mood'].present? %>
-              <div class="text-right">
-                <span class="text-xs text-slate-500">平均体調</span>
-                <p class="text-lg font-bold text-emerald-600 mono">
-                  <%= report.summary_data['avg_mood'] %><span class="text-sm text-slate-500">/5</span>
-                </p>
+            <div class="flex items-start gap-2">
+              <% if report.summary_data.present? && report.summary_data['avg_mood'].present? %>
+                <div class="text-right">
+                  <span class="text-xs text-slate-500">平均体調</span>
+                  <p class="text-lg font-bold text-emerald-600 mono">
+                    <%= report.summary_data['avg_mood'] %><span class="text-sm text-slate-500">/5</span>
+                  </p>
+                </div>
+              <% end %>
+              <%= button_to report, method: :delete,
+                  class: "text-slate-400 hover:text-red-500 transition p-1",
+                  data: { turbo_confirm: "このレポートを削除しますか？" } do %>
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                </svg>
+              <% end %>
+            </div>
+          </div>
+
+          <%= link_to weekly_report_path(report), class: "block" do %>
+            <p class="text-sm text-slate-600 line-clamp-2">
+              <%= truncate(strip_tags(report.content.gsub(/^#+\s*/, '').gsub(/\*\*/, '')), length: 150) %>
+            </p>
+
+            <% if report.predictions.present? && report.predictions['warning_dates']&.any? %>
+              <div class="mt-3 flex items-center gap-2">
+                <span class="inline-flex items-center gap-1 text-xs text-amber-600 bg-amber-50 px-2 py-1 rounded">
+                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+                  </svg>
+                  注意日 <%= report.predictions['warning_dates'].size %>日
+                </span>
               </div>
             <% end %>
-          </div>
 
-          <p class="text-sm text-slate-600 line-clamp-2">
-            <%= truncate(strip_tags(report.content.gsub(/^#+\s*/, '').gsub(/\*\*/, '')), length: 150) %>
-          </p>
-
-          <% if report.predictions.present? && report.predictions['warning_dates']&.any? %>
-            <div class="mt-3 flex items-center gap-2">
-              <span class="inline-flex items-center gap-1 text-xs text-amber-600 bg-amber-50 px-2 py-1 rounded">
-                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
-                </svg>
-                注意日 <%= report.predictions['warning_dates'].size %>日
-              </span>
+            <div class="mt-3 text-emerald-600 text-sm font-medium inline-flex items-center">
+              詳細を見る
+              <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+              </svg>
             </div>
           <% end %>
-
-          <div class="mt-3 text-emerald-600 text-sm font-medium inline-flex items-center">
-            詳細を見る
-            <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
-            </svg>
-          </div>
-        <% end %>
+        </div>
       <% end %>
     </div>
   <% else %>

--- a/app/views/weekly_reports/show.html.erb
+++ b/app/views/weekly_reports/show.html.erb
@@ -94,5 +94,13 @@
       </svg>
       過去のレポート一覧
     <% end %>
+    <%= button_to @weekly_report, method: :delete,
+        class: "btn-danger px-6 py-3 rounded-xl inline-flex items-center justify-center",
+        data: { turbo_confirm: "このレポートを削除しますか？" } do %>
+      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+      </svg>
+      削除
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
         post :import
       end
     end
-    resources :weekly_reports, only: [:index, :show, :create]
+    resources :weekly_reports, only: [:index, :show, :create, :destroy]
     resource :mypage, only: [:show], controller: 'mypage' do
       patch :update_profile, on: :member
       patch :update_password, on: :member

--- a/spec/requests/weekly_reports_spec.rb
+++ b/spec/requests/weekly_reports_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'WeeklyReports', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'DELETE /weekly_reports/:id' do
+    context '認証済みの場合' do
+      before { sign_in user }
+
+      it 'レポートを削除できる' do
+        report = create(:weekly_report, user: user)
+
+        expect {
+          delete weekly_report_path(report)
+        }.to change(WeeklyReport, :count).by(-1)
+      end
+
+      it '削除後に一覧画面にリダイレクトされる' do
+        report = create(:weekly_report, user: user)
+
+        delete weekly_report_path(report)
+
+        expect(response).to redirect_to(weekly_reports_path)
+        follow_redirect!
+        expect(response.body).to include('レポートを削除しました')
+      end
+
+      it '他のユーザーのレポートは削除できない' do
+        other_user = create(:user)
+        other_report = create(:weekly_report, user: other_user)
+
+        expect {
+          delete weekly_report_path(other_report)
+        }.not_to change(WeeklyReport, :count)
+      end
+    end
+
+    context '未認証の場合' do
+      it 'アクセスできない' do
+        report = create(:weekly_report, user: user)
+
+        delete "/weekly_reports/#{report.id}"
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary\n- 週次レポートの削除機能を追加\n- show画面・一覧画面に確認ダイアログ付き削除ボタンを配置\n- 所有者のみ削除可能な認可チェック（`current_user.weekly_reports.find`）\n\n## Changes\n- `config/routes.rb`: `weekly_reports` に `:destroy` 追加\n- `WeeklyReportsController#destroy`: `destroy!` + `RecordNotDestroyed` rescue\n- `application.css`: `btn-danger` カスタムクラス定義\n- `show.html.erb`: 削除ボタン追加（`btn-danger` + `turbo_confirm`）\n- `index.html.erb`: カード構造変更、削除アイコンボタン追加\n- `spec/requests/weekly_reports_spec.rb`: 新規（4テスト）\n\n## Test plan\n- [x] `bundle exec rspec spec/requests/weekly_reports_spec.rb` 全パス\n- [x] `bundle exec rspec` 全226テストパス\n\nCloses #6\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"