### PR TITLE
[feat] レポート対象期間の任意指定フォームを追加 (#7)

### DIFF
--- a/app/services/ai_report_service.rb
+++ b/app/services/ai_report_service.rb
@@ -11,6 +11,7 @@ class AiReportService
   GEMINI_MODEL = "gemini-2.5-flash"
   MINIMUM_PERIOD_RECORDS = 3
   DEFAULT_PERIOD_DAYS = 7
+  MAX_PERIOD_DAYS = 31
 
   def initialize(user)
     @user = user
@@ -34,6 +35,17 @@ class AiReportService
     content = parse_response(response)
 
     create_report(week_start, week_end, content, response)
+  end
+
+  # 対象期間のバリデーション（エラーメッセージ or nil）
+  def validate_period(week_start, week_end)
+    if week_start > Date.current || week_end > Date.current
+      "未来の日付は指定できません"
+    elsif week_end < week_start
+      "終了日は開始日より後の日付を指定してください"
+    elsif (week_end - week_start).to_i + 1 > MAX_PERIOD_DAYS
+      "対象期間は最大#{MAX_PERIOD_DAYS}日間までです"
+    end
   end
 
   # 対象期間内のデータ件数と十分性を返す（1回のクエリで完結）

--- a/app/views/shared/_weekly_report_card.html.erb
+++ b/app/views/shared/_weekly_report_card.html.erb
@@ -29,7 +29,7 @@
     </p>
   <% end %>
 
-  <%= button_to weekly_reports_path, method: :post, class: "btn-primary w-full py-3 rounded-xl font-bold inline-flex items-center justify-center", data: { turbo_submits_with: "生成中..." } do %>
+  <%= link_to new_weekly_report_path, class: "btn-primary w-full py-3 rounded-xl font-bold inline-flex items-center justify-center" do %>
     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
     </svg>

--- a/app/views/weekly_reports/index.html.erb
+++ b/app/views/weekly_reports/index.html.erb
@@ -10,7 +10,7 @@
       <% end %>
       <h1 class="text-2xl sm:text-3xl font-bold text-slate-700">週次レポート履歴</h1>
     </div>
-    <%= button_to weekly_reports_path, method: :post, class: "btn-primary px-6 py-3 rounded-xl font-bold inline-flex items-center justify-center", data: { turbo_submits_with: "生成中..." } do %>
+    <%= link_to new_weekly_report_path, class: "btn-primary px-6 py-3 rounded-xl font-bold inline-flex items-center justify-center" do %>
       <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
       </svg>
@@ -85,7 +85,7 @@
       </div>
       <h3 class="text-lg font-bold text-slate-900 mb-2">まだレポートがありません</h3>
       <p class="text-slate-600 mb-4">最初の週次レポートを生成してみましょう</p>
-      <%= button_to weekly_reports_path, method: :post, class: "btn-primary px-6 py-3 rounded-xl font-bold inline-flex items-center justify-center", data: { turbo_submits_with: "生成中..." } do %>
+      <%= link_to new_weekly_report_path, class: "btn-primary px-6 py-3 rounded-xl font-bold inline-flex items-center justify-center" do %>
         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
         </svg>

--- a/app/views/weekly_reports/new.html.erb
+++ b/app/views/weekly_reports/new.html.erb
@@ -1,0 +1,52 @@
+<div class="w-full max-w-2xl mx-auto">
+  <!-- ヘッダー -->
+  <div class="mb-6 sm:mb-8">
+    <%= link_to authenticated_root_path, class: "text-slate-500 hover:text-slate-700 text-sm inline-flex items-center mb-2" do %>
+      <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+      </svg>
+      ダッシュボードに戻る
+    <% end %>
+    <h1 class="text-2xl sm:text-3xl font-bold text-slate-700">AI週次レポート生成</h1>
+    <p class="text-slate-600 mt-1">対象期間を選択してレポートを生成します</p>
+  </div>
+
+  <!-- フォーム -->
+  <div class="card rounded-2xl p-6 sm:p-8">
+    <%= form_with url: weekly_reports_path, method: :post, class: "space-y-6" do |form| %>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label for="week_start" class="block text-sm font-bold text-slate-700 mb-2">開始日</label>
+          <%= form.date_field :week_start,
+              value: params[:week_start] || @week_start,
+              max: Date.current.to_s,
+              class: "input-field w-full px-4 py-3 rounded-xl text-slate-900 mono" %>
+        </div>
+        <div>
+          <label for="week_end" class="block text-sm font-bold text-slate-700 mb-2">終了日</label>
+          <%= form.date_field :week_end,
+              value: params[:week_end] || @week_end,
+              max: Date.current.to_s,
+              class: "input-field w-full px-4 py-3 rounded-xl text-slate-900 mono" %>
+        </div>
+      </div>
+
+      <div class="bg-slate-50 rounded-xl p-4 text-sm text-slate-600">
+        <ul class="space-y-1">
+          <li>・対象期間は最大<span class="font-bold"><%= AiReportService::MAX_PERIOD_DAYS %>日間</span>まで指定できます</li>
+          <li>・期間内に<span class="font-bold"><%= AiReportService::MINIMUM_PERIOD_RECORDS %>件以上</span>の健康記録が必要です</li>
+          <li>・同じ期間のレポートが既にある場合は生成できません</li>
+        </ul>
+      </div>
+
+      <div class="flex flex-col sm:flex-row gap-3">
+        <%= form.submit "レポートを生成",
+            class: "btn-primary px-6 py-3 rounded-xl font-bold inline-flex items-center justify-center cursor-pointer",
+            data: { turbo_submits_with: "生成中..." } %>
+        <%= link_to weekly_reports_path, class: "btn-secondary px-6 py-3 rounded-xl font-bold inline-flex items-center justify-center" do %>
+          過去のレポート一覧
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/weekly_reports/show.html.erb
+++ b/app/views/weekly_reports/show.html.erb
@@ -82,7 +82,7 @@
 
   <!-- アクションボタン -->
   <div class="mt-6 flex flex-col sm:flex-row gap-3 justify-center">
-    <%= button_to weekly_reports_path, method: :post, class: "btn-primary px-6 py-3 rounded-xl font-bold inline-flex items-center justify-center" do %>
+    <%= link_to new_weekly_report_path, class: "btn-primary px-6 py-3 rounded-xl font-bold inline-flex items-center justify-center" do %>
       <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
       </svg>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
         post :import
       end
     end
-    resources :weekly_reports, only: [:index, :show, :create, :destroy]
+    resources :weekly_reports, only: [:index, :show, :new, :create, :destroy]
     resource :mypage, only: [:show], controller: 'mypage' do
       patch :update_profile, on: :member
       patch :update_password, on: :member

--- a/spec/requests/weekly_reports_spec.rb
+++ b/spec/requests/weekly_reports_spec.rb
@@ -1,7 +1,120 @@
 require 'rails_helper'
 
 RSpec.describe 'WeeklyReports', type: :request do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, :with_location) }
+
+  describe 'GET /weekly_reports/new' do
+    context '認証済みの場合' do
+      before { sign_in user }
+
+      it 'フォーム画面を表示できる' do
+        get new_weekly_report_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('AI週次レポート生成')
+        expect(response.body).to include('開始日')
+        expect(response.body).to include('終了日')
+      end
+    end
+
+    context '未認証の場合' do
+      it 'アクセスできない' do
+        get '/weekly_reports/new'
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'POST /weekly_reports' do
+    before { sign_in user }
+
+    context 'バリデーション' do
+      before do
+        allow(Rails.application.credentials).to receive(:dig).with(:gemini_api_key).and_return('test_api_key')
+      end
+
+      it '終了日が開始日より前の場合エラーになる' do
+        post weekly_reports_path, params: {
+          week_start: '2026-02-10',
+          week_end: '2026-02-05'
+        }
+
+        expect(response).to redirect_to(new_weekly_report_path(week_start: '2026-02-10', week_end: '2026-02-05'))
+        follow_redirect!
+        expect(response.body).to include('終了日は開始日より後の日付を指定してください')
+      end
+
+      it '未来の日付が指定された場合エラーになる' do
+        future_date = (Date.current + 5).to_s
+        post weekly_reports_path, params: {
+          week_start: Date.current.to_s,
+          week_end: future_date
+        }
+
+        expect(response).to redirect_to(new_weekly_report_path(week_start: Date.current.to_s, week_end: future_date))
+        follow_redirect!
+        expect(response.body).to include('未来の日付は指定できません')
+      end
+
+      it "#{AiReportService::MAX_PERIOD_DAYS}日を超える期間はエラーになる" do
+        week_start = (Date.current - 40).to_s
+        week_end = (Date.current - 1).to_s
+        post weekly_reports_path, params: {
+          week_start: week_start,
+          week_end: week_end
+        }
+
+        expect(response).to redirect_to(new_weekly_report_path(week_start: week_start, week_end: week_end))
+        follow_redirect!
+        expect(response.body).to include("対象期間は最大#{AiReportService::MAX_PERIOD_DAYS}日間までです")
+      end
+
+      it "ちょうど#{AiReportService::MAX_PERIOD_DAYS}日間は期間バリデーションを通過する" do
+        week_start = Date.current - AiReportService::MAX_PERIOD_DAYS
+        week_end = Date.current - 1
+        post weekly_reports_path, params: {
+          week_start: week_start.to_s,
+          week_end: week_end.to_s
+        }
+
+        # 期間上限エラーではない（データ不足リダイレクトは許容）
+        if response.redirect?
+          follow_redirect!
+          expect(response.body).not_to include("対象期間は最大#{AiReportService::MAX_PERIOD_DAYS}日間までです")
+        end
+      end
+
+      it '不正な日付形式の場合はデフォルト値にフォールバックする' do
+        post weekly_reports_path, params: {
+          week_start: 'invalid',
+          week_end: 'invalid'
+        }
+
+        # デフォルト値が適用されるため、期間バリデーションエラーにはならない
+        expect(response).not_to have_http_status(:internal_server_error)
+      end
+
+      it 'パラメータ未送信の場合はデフォルト値で動作する' do
+        post weekly_reports_path
+
+        expect(response).not_to have_http_status(:internal_server_error)
+      end
+
+      it '開始日が未来の場合エラーになる' do
+        future_start = (Date.current + 3).to_s
+        future_end = (Date.current + 5).to_s
+        post weekly_reports_path, params: {
+          week_start: future_start,
+          week_end: future_end
+        }
+
+        expect(response).to redirect_to(new_weekly_report_path(week_start: future_start, week_end: future_end))
+        follow_redirect!
+        expect(response.body).to include('未来の日付は指定できません')
+      end
+    end
+  end
 
   describe 'DELETE /weekly_reports/:id' do
     context '認証済みの場合' do

--- a/spec/services/ai_report_service_spec.rb
+++ b/spec/services/ai_report_service_spec.rb
@@ -88,6 +88,38 @@ RSpec.describe AiReportService do
     end
   end
 
+  describe '#validate_period' do
+    it 'returns nil for valid period' do
+      result = service.validate_period(Date.current - 7, Date.current - 1)
+      expect(result).to be_nil
+    end
+
+    it 'returns error when end is before start' do
+      result = service.validate_period(Date.current - 1, Date.current - 7)
+      expect(result).to include('終了日は開始日より後')
+    end
+
+    it 'returns error when start is in the future' do
+      result = service.validate_period(Date.current + 1, Date.current + 3)
+      expect(result).to include('未来の日付')
+    end
+
+    it 'returns error when end is in the future' do
+      result = service.validate_period(Date.current - 3, Date.current + 1)
+      expect(result).to include('未来の日付')
+    end
+
+    it 'returns error when period exceeds MAX_PERIOD_DAYS' do
+      result = service.validate_period(Date.current - 40, Date.current - 1)
+      expect(result).to include("最大#{AiReportService::MAX_PERIOD_DAYS}日間")
+    end
+
+    it 'returns nil for exactly MAX_PERIOD_DAYS period' do
+      result = service.validate_period(Date.current - AiReportService::MAX_PERIOD_DAYS, Date.current - 1)
+      expect(result).to be_nil
+    end
+  end
+
   describe '#generate_weekly_report' do
     let(:gemini_response) do
       [


### PR DESCRIPTION
## Summary\n- レポート生成時に開始日・終了日を任意指定できるフォーム画面を追加\n- 期間バリデーション（未来日不可、開始>終了不可、最大31日間）をAiReportServiceに実装\n- 既存の全生成ボタンをフォーム画面(new)へのリンクに統一\n\n## Changes\n- `AiReportService`: `MAX_PERIOD_DAYS = 31` 定数 + `validate_period` メソッド追加\n- `config/routes.rb`: `:new` 追加\n- `WeeklyReportsController`: `new` アクション、`create` パラメータ対応、`parse_date` メソッド\n- `weekly_reports/new.html.erb`: 期間指定フォーム新規作成\n- `show/index/_weekly_report_card`: 生成ボタンを `new` リンクに変更\n- テスト: `validate_period` 6件 + リクエストスペック7件 追加\n\n## Test plan\n- [x] `bundle exec rspec spec/services/ai_report_service_spec.rb` 全パス\n- [x] `bundle exec rspec spec/requests/weekly_reports_spec.rb` 全パス\n- [x] `bundle exec rspec` 全246テストパス\n\nCloses #7\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"